### PR TITLE
fix: resolve dependency addresses from the bridge address, not assignedPort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "thunderhub-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "lnd-startos": "github:Start9Labs/lnd-startos#next"
       },
       "devDependencies": {
@@ -62,9 +62,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.7.tgz",
-      "integrity": "sha512-lJuZto0vfD/2fPubzwavuStAdlnQQo8AmYFvBBhENY4WbXAXJ64b5zuXwrkmJ8wZObUngno5LYZWWr7yOlYLxQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.9.tgz",
+      "integrity": "sha512-HuSYrS10Bb+f6OyAMlCzd5Qyr+rIauiI0dF8MVh5Ny+eU0gF8/DeFAXlHFgL+9wkSv4UAP5q5yOzlBpXzsNbWQ==",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",
@@ -333,163 +333,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core": {
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "deep-equality-data-structures": "^2.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "4.4.3",
-        "zod-deep-partial": "^1.4.4"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@iarna/toml": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/deep-equality-data-structures": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-hash": "^3.0.0"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/mime": {
-      "version": "4.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/object-hash": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/tr46": {
-      "version": "0.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/yaml": {
-      "version": "2.9.0",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod": {
-      "version": "4.4.3",
-      "inBundle": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod-deep-partial": {
-      "version": "1.4.4",
-      "inBundle": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "zod": "^4.1.13"
       }
     },
     "node_modules/@start9labs/start-sdk/node_modules/@types/estree": {
@@ -1581,6 +1424,1480 @@
         "tor-startos": "github:Start9Labs/tor-startos#next"
       }
     },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.7.tgz",
+      "integrity": "sha512-lJuZto0vfD/2fPubzwavuStAdlnQQo8AmYFvBBhENY4WbXAXJ64b5zuXwrkmJ8wZObUngno5LYZWWr7yOlYLxQ==",
+      "bundleDependencies": [
+        "@start9labs/start-core",
+        "eslint",
+        "typescript-eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@start9labs/start-core": "file:./node_modules/@start9labs/start-core",
+        "@types/ini": "^4.1.1",
+        "deep-equality-data-structures": "^2.0.0",
+        "eslint": "^9.39.4",
+        "fast-xml-parser": "~5.7.0",
+        "ini": "^5.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "typescript-eslint": "^8.61.0",
+        "yaml": "^2.8.3",
+        "zod": "4.4.3",
+        "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core": {
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "deep-equality-data-structures": "^2.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "yaml": "^2.8.3",
+        "zod": "4.4.3",
+        "zod-deep-partial": "^1.4.4"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@iarna/toml": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/deep-equality-data-structures": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-hash": "^3.0.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/mime": {
+      "version": "4.1.0",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/object-hash": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/tr46": {
+      "version": "0.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/yaml": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod": {
+      "version": "4.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod-deep-partial": {
+      "version": "1.4.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/parser": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/types": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/acorn": {
+      "version": "8.16.0",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/ajv": {
+      "version": "6.15.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/callsites": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/chalk": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/deep-is": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint": {
+      "version": "9.39.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/espree": {
+      "version": "10.4.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/esquery": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/esrecurse": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/estraverse": {
+      "version": "5.3.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/esutils": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/fdir": {
+      "version": "6.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/flatted": {
+      "version": "3.4.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/globals": {
+      "version": "14.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/import-fresh": {
+      "version": "3.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/is-glob": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/isexe": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/keyv": {
+      "version": "4.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/levn": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/natural-compare": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/optionator": {
+      "version": "0.9.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/p-limit": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/parent-module": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/path-exists": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/path-key": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/picomatch": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/type-check": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/typescript-eslint": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/which": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/word-wrap": {
+      "version": "1.2.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/deep-equality-data-structures/-/deep-equality-data-structures-2.0.0.tgz",
@@ -1671,6 +2988,1480 @@
         "mime": "^4.0.7",
         "rfc4648": "1.5.4",
         "tor-startos": "github:Start9Labs/tor-startos#next"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.7.tgz",
+      "integrity": "sha512-lJuZto0vfD/2fPubzwavuStAdlnQQo8AmYFvBBhENY4WbXAXJ64b5zuXwrkmJ8wZObUngno5LYZWWr7yOlYLxQ==",
+      "bundleDependencies": [
+        "@start9labs/start-core",
+        "eslint",
+        "typescript-eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@start9labs/start-core": "file:./node_modules/@start9labs/start-core",
+        "@types/ini": "^4.1.1",
+        "deep-equality-data-structures": "^2.0.0",
+        "eslint": "^9.39.4",
+        "fast-xml-parser": "~5.7.0",
+        "ini": "^5.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "typescript-eslint": "^8.61.0",
+        "yaml": "^2.8.3",
+        "zod": "4.4.3",
+        "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core": {
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "deep-equality-data-structures": "^2.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "yaml": "^2.8.3",
+        "zod": "4.4.3",
+        "zod-deep-partial": "^1.4.4"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@iarna/toml": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/deep-equality-data-structures": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-hash": "^3.0.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/mime": {
+      "version": "4.1.0",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/object-hash": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/tr46": {
+      "version": "0.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/yaml": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod": {
+      "version": "4.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod-deep-partial": {
+      "version": "1.4.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/parser": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/types": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/acorn": {
+      "version": "8.16.0",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/ajv": {
+      "version": "6.15.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/callsites": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/chalk": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/deep-is": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint": {
+      "version": "9.39.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/espree": {
+      "version": "10.4.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/esquery": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/esrecurse": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/estraverse": {
+      "version": "5.3.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/esutils": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/fdir": {
+      "version": "6.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/flatted": {
+      "version": "3.4.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/globals": {
+      "version": "14.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/import-fresh": {
+      "version": "3.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/is-glob": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/isexe": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/keyv": {
+      "version": "4.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/levn": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/natural-compare": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/optionator": {
+      "version": "0.9.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/p-limit": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/parent-module": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/path-exists": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/path-key": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/picomatch": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/type-check": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/typescript-eslint": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/which": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/word-wrap": {
+      "version": "1.2.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mime": {
@@ -1781,6 +4572,1480 @@
         "@noble/curves": "*",
         "@start9labs/start-sdk": "2.0.7",
         "rfc4648": "^1.5.4"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.7.tgz",
+      "integrity": "sha512-lJuZto0vfD/2fPubzwavuStAdlnQQo8AmYFvBBhENY4WbXAXJ64b5zuXwrkmJ8wZObUngno5LYZWWr7yOlYLxQ==",
+      "bundleDependencies": [
+        "@start9labs/start-core",
+        "eslint",
+        "typescript-eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@start9labs/start-core": "file:./node_modules/@start9labs/start-core",
+        "@types/ini": "^4.1.1",
+        "deep-equality-data-structures": "^2.0.0",
+        "eslint": "^9.39.4",
+        "fast-xml-parser": "~5.7.0",
+        "ini": "^5.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "typescript-eslint": "^8.61.0",
+        "yaml": "^2.8.3",
+        "zod": "4.4.3",
+        "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core": {
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "deep-equality-data-structures": "^2.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "yaml": "^2.8.3",
+        "zod": "4.4.3",
+        "zod-deep-partial": "^1.4.4"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@iarna/toml": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/deep-equality-data-structures": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-hash": "^3.0.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/mime": {
+      "version": "4.1.0",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/object-hash": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/tr46": {
+      "version": "0.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/yaml": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod": {
+      "version": "4.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod-deep-partial": {
+      "version": "1.4.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/parser": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/types": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/utils": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/acorn": {
+      "version": "8.16.0",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/ajv": {
+      "version": "6.15.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/callsites": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/chalk": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/deep-is": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint": {
+      "version": "9.39.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/espree": {
+      "version": "10.4.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/esquery": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/esrecurse": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/estraverse": {
+      "version": "5.3.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/esutils": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/fdir": {
+      "version": "6.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/flatted": {
+      "version": "3.4.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/globals": {
+      "version": "14.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/import-fresh": {
+      "version": "3.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/is-glob": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/isexe": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/keyv": {
+      "version": "4.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/levn": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/natural-compare": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/optionator": {
+      "version": "0.9.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/p-limit": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/parent-module": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/path-exists": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/path-key": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/picomatch": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/type-check": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/typescript-eslint": {
+      "version": "8.61.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/which": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/word-wrap": {
+      "version": "1.2.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tor-startos/node_modules/@start9labs/start-sdk/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "2.0.7",
+    "@start9labs/start-sdk": "2.0.9",
     "lnd-startos": "github:Start9Labs/lnd-startos#next"
   },
   "devDependencies": {

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -3,7 +3,7 @@ import { manifest as lndManifest } from 'lnd-startos/startos/manifest'
 import { accountsYaml, defaultAccount } from './fileModels/accounts.yaml'
 import { i18n } from './i18n'
 import { sdk } from './sdk'
-import { accountsPath, bridgeAddress, dataDir, lndMount, uiPort } from './utils'
+import { accountsPath, dataDir, lndMount, uiPort } from './utils'
 
 export const main = sdk.setupMain(async ({ effects }) => {
   /**
@@ -42,11 +42,13 @@ export const main = sdk.setupMain(async ({ effects }) => {
   // and heals with one restart when the binding lands — no separate macaroon
   // watch needed. null also propagates on LND uninstall, dropping serverUrl so
   // ThunderHub reconfigures instead of dialing a stale port.
-  const grpcHost = await bridgeAddress(effects, {
-    packageId: 'lnd',
-    hostId: gRPCHostId,
-    internalPort: gRPCPort,
-  }).const()
+  const grpcHost = await sdk.host
+    .getBridgeAddress(effects, {
+      packageId: 'lnd',
+      hostId: gRPCHostId,
+      internalPort: gRPCPort,
+    })
+    .const()
 
   await accountsYaml.merge(effects, {
     accounts: [{ ...defaultAccount, serverUrl: grpcHost ?? undefined }],

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -1,59 +1,6 @@
-import { T } from '@start9labs/start-sdk'
 import { sdk } from './sdk'
 
 export const uiPort = 3000
 export const dataDir = '/data' as const
 export const lndMount = '/mnt/lnd' as const
 export const accountsPath = `${dataDir}/accounts.yaml` as const
-
-/**
- * Bridge address (`10.0.3.1:<assigned external port>`) of a dependency's
- * binding, as a minimal reactive value. Chain `.const()` in main: the mapped
- * string only changes when the address itself does, so main restarts exactly
- * on dependency install/uninstall/port-change and never on dependency
- * updates. Chain `.once()` in an action context. `fallbackPort` keeps the
- * value non-null while the dependency is absent — sanctioned only for tor's
- * allocator-guaranteed SOCKS 9050. Drop-in for the planned SDK
- * `sdk.host.getBridgeAddress` helper.
- */
-export function bridgeAddress(
-  effects: T.Effects,
-  opts: {
-    packageId: string
-    hostId: string
-    internalPort: number
-    fallbackPort: number
-  },
-): { const(): Promise<string>; once(): Promise<string> }
-export function bridgeAddress(
-  effects: T.Effects,
-  opts: { packageId: string; hostId: string; internalPort: number },
-): { const(): Promise<string | null>; once(): Promise<string | null> }
-export function bridgeAddress(
-  effects: T.Effects,
-  opts: {
-    packageId: string
-    hostId: string
-    internalPort: number
-    fallbackPort?: number
-  },
-) {
-  const watchable = async () => {
-    const osIp = await sdk.getOsIp(effects)
-    return sdk.host.get(
-      effects,
-      { packageId: opts.packageId, hostId: opts.hostId },
-      (host) => {
-        const port =
-          host?.bindings[opts.internalPort]?.net.assignedPort ??
-          opts.fallbackPort
-        if (port == null) return null
-        return `${osIp}:${port}`
-      },
-    )
-  }
-  return {
-    const: async () => (await watchable()).const(),
-    once: async () => (await watchable()).once(),
-  }
-}

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,23 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.18.4:2',
+  version: '0.18.4:3',
   releaseNotes: {
-    en_US: 'Internal updates',
-    es_ES: 'Actualizaciones internas',
-    de_DE: 'Interne Aktualisierungen',
-    pl_PL: 'Aktualizacje wewnętrzne',
-    fr_FR: 'Mises à jour internes',
+    en_US: `Keeps the LND connection working when LND changes how it serves TLS.
+
+Thunderhub resolved LND's address from a field that is only populated for one of the two ways a service can publish a port. It now reads the address itself, which is correct either way — so the connection survives LND's next update instead of going unreachable.`,
+    es_ES: `Mantiene la conexión con LND cuando LND cambia su forma de servir TLS.
+
+Thunderhub resolvía la dirección de LND a partir de un campo que solo se rellena en una de las dos formas en que un servicio puede publicar un puerto. Ahora lee la dirección en sí, que es correcta en ambos casos, así que la conexión sobrevive a la próxima actualización de LND en lugar de quedar inaccesible.`,
+    de_DE: `Hält die LND-Verbindung aufrecht, wenn LND die Art der TLS-Bereitstellung ändert.
+
+Thunderhub ermittelte die Adresse von LND aus einem Feld, das nur bei einer der beiden Arten gefüllt ist, auf die ein Dienst einen Port veröffentlichen kann. Jetzt wird die Adresse selbst gelesen, die in beiden Fällen stimmt — die Verbindung übersteht damit das nächste LND-Update, statt unerreichbar zu werden.`,
+    pl_PL: `Utrzymuje połączenie z LND, gdy LND zmienia sposób udostępniania TLS.
+
+Thunderhub ustalał adres LND na podstawie pola wypełnianego tylko przy jednym z dwóch sposobów publikowania portu przez usługę. Teraz odczytuje sam adres, poprawny w obu przypadkach — dzięki temu połączenie przetrwa kolejną aktualizację LND, zamiast stać się nieosiągalne.`,
+    fr_FR: `Maintient la connexion à LND lorsque LND change sa façon de servir TLS.
+
+Thunderhub déterminait l'adresse de LND à partir d'un champ renseigné dans un seul des deux modes de publication d'un port par un service. Il lit désormais l'adresse elle-même, correcte dans les deux cas — la connexion survit donc à la prochaine mise à jour de LND au lieu de devenir injoignable.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Why

This package resolved its dependencies' addresses by reading `bindings[<port>].net.assignedPort`. That field is raw metadata, and **which** port field is populated depends on how the dependency bound the port — a binding with `addSsl` frees `assignedPort` entirely and carries only `assignedSslPort`.

LND hit exactly this when it moved REST behind the OS reverse proxy (Start9Labs/lnd-startos#171): every dependent silently resolved `null`.

## What changed

Adopts **`sdk.host.getBridgeAddress`**, added in start-sdk 2.0.9 (Start9Labs/start-technologies#3560, #3561), and deletes the local copy of the helper this package was carrying — one of 44 near-identical copies across the fleet.

The helper resolves the binding's own derived bridge address, which is correct whether the dependency terminates its own TLS or hands the port to the OS proxy. It is computed per binding rather than per exported interface, so it also resolves bridge-only bindings such as tor's SOCKS proxy.

`ssl:` is passed **only** where the target binding publishes two bridge addresses — `protocol: 'http'`/`'ws'`, or `secure: null` with `addSsl`. bitcoind's RPC is the clearest case (`10.0.3.1:8332 ssl=false` alongside `10.0.3.1:54404 ssl=true`), so an undiscriminated lookup there is order-dependent. Where a binding publishes one address no discriminator is passed — pinning one would assert a fact about how the dependency binds, the coupling this change removes.

## On the lockfile diff

Larger than expected, and expected to stay that way for now. This package pins git dependencies that track `#next` branches, which still resolve start-sdk 2.0.7, so npm nests a second SDK copy rather than hoisting one. It collapses once those `next` branches carry 2.0.9. The lockfile has to be committed regardless — `s9pk.mk` and the reusable CI both run `npm ci`, which fails on a lockfile out of sync with `package.json`. Functionally inert: the git deps are imported for types, and the s9pk build tree-shakes.

## Verification

`tsc` and prettier clean against the published start-sdk 2.0.9. The resolution logic was verified live on a StartOS 0.4.0-beta.10 box: with LND on `addSsl`, `net.assignedPort` reads `null` while the binding's bridge entry resolves to `10.0.3.1:8080`; LNbits connected through it (`✔️ Backend LndRestWallet connected`), and Fulcrum picked bitcoind's plaintext `:8332` leg over the TLS `:54404` one.

Not exercised against a running instance of this service — compile-checked only.

## Test plan

1. Install this build alongside its dependencies.
2. Confirm it connects to each one and its health checks go green.
3. Restart a dependency and confirm the address re-resolves without a restart loop — `.const()` should settle on one value and stay there.
